### PR TITLE
UPPSF-67 memory leak fix

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,17 @@
 
 
 [[projects]]
+  digest = "1:1c88bd70d3ac8f9e843571d4227261e1f7f7ba13d78a3942b95f41f0c726aedf"
+  name = "github.com/Financial-Times/go-ft-http"
+  packages = [
+    "fthttp",
+    "transport",
+  ]
+  pruneopts = "UT"
+  revision = "5a93c30a228457c72254f628da251ef540ffcad2"
+  version = "0.0.4"
+
+[[projects]]
   digest = "1:3b7e921b3c7c81a1ea711e8d515d99e8cf0a12905ab5dafb962b51bac2741aaf"
   name = "github.com/Financial-Times/go-fthealth"
   packages = ["v1_1"]
@@ -194,6 +205,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Financial-Times/go-ft-http/fthttp",
     "github.com/Financial-Times/go-fthealth/v1_1",
     "github.com/Financial-Times/go-logger",
     "github.com/Financial-Times/http-handlers-go/httphandlers",

--- a/app.go
+++ b/app.go
@@ -23,10 +23,11 @@ import (
 var httpClient = http.Client{
 	Transport: &http.Transport{
 		MaxIdleConnsPerHost: 128,
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+			DualStack: true,
+		}).DialContext,
 	},
 }
 

--- a/app.go
+++ b/app.go
@@ -26,7 +26,6 @@ var httpClient = http.Client{
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 	},
 }

--- a/things/handlers.go
+++ b/things/handlers.go
@@ -316,17 +316,14 @@ func (rh *ThingsHandler) getThingViaConceptsApi(UUID string, relationships []str
 
 	request.Header.Set("X-Request-Id", transID)
 	resp, err := rh.client.Do(request)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		msg := fmt.Sprintf("request to %s was unsuccessful", reqURL)
-		if resp != nil {
-			msg = fmt.Sprintf("request to %s returned status: %d", reqURL, resp.StatusCode)
-		}
 		logger.WithError(err).WithUUID(UUID).WithTransactionID(transID).Error(msg)
 		return mappedConcept, false, err
 	}
+
+	defer resp.Body.Close()
+
 	if resp.StatusCode == http.StatusNotFound {
 		return mappedConcept, false, nil
 	}

--- a/things/handlers.go
+++ b/things/handlers.go
@@ -315,6 +315,8 @@ func (rh *ThingsHandler) getThingViaConceptsApi(UUID string, relationships []str
 	}
 
 	request.Header.Set("X-Request-Id", transID)
+	request.Header.Set("User-Agent", "UPP public-things-api")
+
 	resp, err := rh.client.Do(request)
 	if err != nil {
 		msg := fmt.Sprintf("request to %s was unsuccessful", reqURL)

--- a/things/handlers.go
+++ b/things/handlers.go
@@ -315,7 +315,6 @@ func (rh *ThingsHandler) getThingViaConceptsApi(UUID string, relationships []str
 	}
 
 	request.Header.Set("X-Request-Id", transID)
-	request.Header.Set("User-Agent", "UPP public-things-api")
 
 	resp, err := rh.client.Do(request)
 	if err != nil {
@@ -429,8 +428,6 @@ func (h *ThingsHandler) Checker() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	req.Header.Add("User-Agent", "UPP public-things-api")
 
 	resp, err := h.client.Do(req)
 	if err != nil {

--- a/things/handlers.go
+++ b/things/handlers.go
@@ -316,8 +316,14 @@ func (rh *ThingsHandler) getThingViaConceptsApi(UUID string, relationships []str
 
 	request.Header.Set("X-Request-Id", transID)
 	resp, err := rh.client.Do(request)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
-		msg := fmt.Sprintf("request to %s returned status: %d", reqURL, resp.StatusCode)
+		msg := fmt.Sprintf("request to %s was unsuccessful", reqURL)
+		if resp != nil {
+			msg = fmt.Sprintf("request to %s returned status: %d", reqURL, resp.StatusCode)
+		}
 		logger.WithError(err).WithUUID(UUID).WithTransactionID(transID).Error(msg)
 		return mappedConcept, false, err
 	}


### PR DESCRIPTION
Fixed memory leak due to not closing the request body after making http request.
Also update the init of http client to use DialContext instead of the deprecated Dial, DialContext allows the transport to cancel dials as soon as they are no longer needed.